### PR TITLE
Clarify docs as design-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 ## Overview
 
-This repository contains an advanced, enterprise-level Supply Chain Management (SCM) system designed specifically for pharmaceutical manufacturers, Clearing & Forwarding Agents (CFAs), and stockists. The system ensures a tightly controlled in-house process flow where the Manufacturer retains authoritative oversight, with all CFA actions requiring explicit Manufacturer approval.
+This repository contains plans for an advanced, enterprise-level Supply Chain Management (SCM) system designed specifically for pharmaceutical manufacturers, Clearing & Forwarding Agents (CFAs), and stockists. The system ensures a tightly controlled in-house process flow where the Manufacturer retains authoritative oversight, with all CFA actions requiring explicit Manufacturer approval.
+
+## Project Status
+
+At the moment this repository only includes documentation describing the intended architecture and workflows.  The backend and frontend code referenced below has not yet been implemented.  The documents serve as a blueprint for future development.
 
 ## Key Functionalities
 
@@ -56,6 +60,8 @@ This repository contains an advanced, enterprise-level Supply Chain Management (
 - Notification banner & snackbar system for feedback
 
 ## Repository File Structure
+
+The layout below illustrates the planned organization of the project.  The actual directories have not been created yet.
 
 ```
 supply-chain-management/
@@ -112,6 +118,8 @@ supply-chain-management/
 - **Receipts & Order History:** Downloadable invoices & logs
 
 ## Installation and Setup
+
+The following commands reflect the intended project structure.  The repository currently lacks the `backend` and `frontend` directories, so these steps serve as guidance for future implementation.
 
 ### Backend
 

--- a/backend_AGENTS.md
+++ b/backend_AGENTS.md
@@ -1,6 +1,6 @@
 # **backend\_agents.md: Backend Interactions for Pharmaceutical Supply Chain Management System**
 
-This document details the backend architecture and how it facilitates interactions between the three user roles (Manufacturer, CFA, Stockist) within the Pharmaceutical Supply Chain Management System. The Flask backend serves as the central hub, managing data, enforcing business rules, and controlling access via a RESTful API.
+This document details the proposed backend architecture and how it will facilitate interactions between the three user roles (Manufacturer, CFA, Stockist) within the Pharmaceutical Supply Chain Management System.  At present no backend code exists in this repository; the design below serves as a blueprint for future implementation.  The intended Flask backend will act as the central hub, managing data, enforcing business rules, and controlling access via a RESTful API.
 
 ## **1\. Core Backend Principles**
 

--- a/frontend_AGENTS.md
+++ b/frontend_AGENTS.md
@@ -1,6 +1,6 @@
 # **frontend\_agents.md: Enhanced Frontend Interactions for Pharmaceutical Supply Chain Management System**
 
-This document outlines the design and enhanced interaction patterns of the three primary user dashboards (manufacturer.html, cfa.html, stockist.html) within the Pharmaceutical Supply Chain Management System. It details how these dashboards connect to the backend API, handle user interactions, display information relevant to each role, and includes suggestions for richer functionalities.
+This document outlines the proposed design and enhanced interaction patterns of the three primary user dashboards (manufacturer.html, cfa.html, stockist.html) within the Pharmaceutical Supply Chain Management System.  The repository currently does not include these frontend pages or accompanying JavaScript; this file serves purely as a design reference.  It details how the dashboards will connect to the backend API, handle user interactions, display information relevant to each role, and includes suggestions for richer functionalities.
 
 ## **1\. Core Frontend Principles (Retained & Enhanced)**
 


### PR DESCRIPTION
## Summary
- mark README as a design document rather than working code
- add notes that the planned folder structure and setup steps are not yet implemented
- note in backend and frontend design docs that no code currently exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68592eadd1c4832aa44b7b6bd5a90bd3