### PR TITLE
Bulk operations, orders and cart features

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -23,11 +23,15 @@ def create_app(config_class=None):
     from .routes.products import products_bp
     from .routes.inventory import inventory_bp
     from .routes.requests import requests_bp
+    from .routes.orders import orders_bp
+    from .routes.users import users_bp
 
     app.register_blueprint(auth_bp, url_prefix='/auth')
     app.register_blueprint(products_bp, url_prefix='/products')
     app.register_blueprint(inventory_bp, url_prefix='/inventory')
     app.register_blueprint(requests_bp, url_prefix='/requests')
+    app.register_blueprint(orders_bp, url_prefix='/orders')
+    app.register_blueprint(users_bp, url_prefix='/users')
 
     with app.app_context():
         db.create_all()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,5 +3,6 @@ from .role import Role
 from .product import Product
 from .inventory import Inventory
 from .approval_request import ApprovalRequest
+from .order import Order
 
-__all__ = ['User', 'Role', 'Product', 'Inventory', 'ApprovalRequest']
+__all__ = ['User', 'Role', 'Product', 'Inventory', 'ApprovalRequest', 'Order']

--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+from .. import db
+
+
+class Order(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    stockist_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    items = db.Column(db.Text, nullable=False)  # JSON string
+    status = db.Column(db.String(20), default='pending')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)

--- a/backend/app/routes/orders.py
+++ b/backend/app/routes/orders.py
@@ -1,0 +1,31 @@
+import json
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import get_jwt_identity
+
+from .. import db
+from ..models import User
+from ..services.orders import create_order, list_orders
+from ...utils.decorators import role_required
+
+
+orders_bp = Blueprint('orders', __name__)
+
+
+@orders_bp.route('/', methods=['GET'])
+@role_required('Manufacturer', 'Stockist')
+def get_orders():
+    user = User.query.get(get_jwt_identity())
+    orders = list_orders(user)
+    return jsonify([
+        {'id': o.id, 'items': json.loads(o.items), 'status': o.status}
+        for o in orders
+    ])
+
+
+@orders_bp.route('/', methods=['POST'])
+@role_required('Stockist')
+def place_order():
+    data = request.get_json() or {}
+    items = data.get('items', [])
+    order = create_order(get_jwt_identity(), items)
+    return jsonify({'id': order.id}), 201

--- a/backend/app/routes/requests.py
+++ b/backend/app/routes/requests.py
@@ -3,7 +3,14 @@ from flask_jwt_extended import get_jwt_identity
 
 from .. import db
 from ..models import ApprovalRequest
-from ..services.requests import create_request, approve_request, deny_request
+from ..services.requests import (
+    create_request,
+    approve_request,
+    deny_request,
+    bulk_approve_requests,
+    bulk_deny_requests,
+    create_draft_request,
+)
 from ...utils.decorators import role_required
 
 requests_bp = Blueprint('requests', __name__)
@@ -13,11 +20,20 @@ requests_bp = Blueprint('requests', __name__)
 def list_requests():
     status = request.args.get('status')
     requester_id = request.args.get('requester_id')
+    product_id = request.args.get('product')
+    start = request.args.get('start')
+    end = request.args.get('end')
     query = ApprovalRequest.query
     if status:
         query = query.filter_by(status=status)
     if requester_id:
         query = query.filter_by(requester_id=int(requester_id))
+    if product_id:
+        query = query.filter_by(product_id=int(product_id))
+    if start:
+        query = query.filter(ApprovalRequest.created_at >= start)
+    if end:
+        query = query.filter(ApprovalRequest.created_at <= end)
     requests_list = query.all()
     return jsonify([
         {
@@ -43,6 +59,18 @@ def new_request():
     req_obj = create_request(get_jwt_identity(), product_id, action, quantity, location_id)
     return jsonify({'id': req_obj.id}), 201
 
+
+@requests_bp.route('/draft', methods=['POST'])
+@role_required('CFA')
+def save_draft():
+    data = request.get_json() or {}
+    product_id = data.get('product_id')
+    action = data.get('action')
+    quantity = data.get('quantity', 0)
+    location_id = data.get('location_id', 0)
+    req_obj = create_draft_request(get_jwt_identity(), product_id, action, quantity, location_id)
+    return jsonify({'id': req_obj.id}), 201
+
 @requests_bp.route('/<int:id>/approve', methods=['PUT'])
 @role_required('Manufacturer')
 def approve(id):
@@ -56,3 +84,21 @@ def deny(id):
     req_obj = ApprovalRequest.query.get_or_404(id)
     deny_request(req_obj, get_jwt_identity())
     return jsonify({'msg': 'denied'})
+
+
+@requests_bp.route('/bulk-approve', methods=['PUT'])
+@role_required('Manufacturer')
+def bulk_approve():
+    data = request.get_json() or {}
+    ids = data.get('ids', [])
+    bulk_approve_requests(ids, get_jwt_identity())
+    return jsonify({'approved': ids})
+
+
+@requests_bp.route('/bulk-deny', methods=['PUT'])
+@role_required('Manufacturer')
+def bulk_deny():
+    data = request.get_json() or {}
+    ids = data.get('ids', [])
+    bulk_deny_requests(ids, get_jwt_identity())
+    return jsonify({'denied': ids})

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -1,0 +1,30 @@
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import get_jwt_identity
+
+from .. import db
+from ..models import User
+from ...utils.decorators import role_required
+
+users_bp = Blueprint('users', __name__)
+
+
+@users_bp.route('/me', methods=['GET'])
+@role_required('Stockist')
+def get_profile():
+    user = User.query.get(get_jwt_identity())
+    return jsonify({'username': user.username, 'email': user.email})
+
+
+@users_bp.route('/me', methods=['PUT'])
+@role_required('Stockist')
+def update_profile():
+    user = User.query.get(get_jwt_identity())
+    data = request.get_json() or {}
+    if 'username' in data:
+        user.username = data['username']
+    if 'email' in data:
+        user.email = data['email']
+    if 'password' in data and 'current_password' in data and User.verify_hash(data['current_password'], user.password_hash):
+        user.password_hash = User.generate_hash(data['password'])
+    db.session.commit()
+    return jsonify({'msg': 'updated'})

--- a/backend/app/services/orders.py
+++ b/backend/app/services/orders.py
@@ -1,0 +1,16 @@
+import json
+from .. import db
+from ..models import Order
+
+
+def create_order(stockist_id, items):
+    order = Order(stockist_id=stockist_id, items=json.dumps(items))
+    db.session.add(order)
+    db.session.commit()
+    return order
+
+
+def list_orders(user):
+    if user.role.name == 'Manufacturer':
+        return Order.query.all()
+    return Order.query.filter_by(stockist_id=user.id).all()

--- a/backend/app/services/products.py
+++ b/backend/app/services/products.py
@@ -7,3 +7,41 @@ def create_product(name, description, price, manufacturer_id):
     db.session.add(product)
     db.session.commit()
     return product
+
+
+def bulk_create_products(data_list):
+    """Create multiple products at once.
+
+    Each item in ``data_list`` should be a dict with keys ``name``, ``description``,
+    ``price`` and ``manufacturer_id``. The operation is executed in a single
+    transaction so either all products are created or none.
+    """
+    products = [
+        Product(name=item['name'],
+                description=item.get('description', ''),
+                price=item['price'],
+                manufacturer_id=item['manufacturer_id'])
+        for item in data_list
+    ]
+    db.session.add_all(products)
+    db.session.commit()
+    return products
+
+
+def bulk_update_products(data_list):
+    """Update multiple products.
+
+    ``data_list`` is a list of dictionaries, each containing at least ``id`` and
+    the fields to update. Missing fields are ignored.
+    """
+    updated = []
+    for item in data_list:
+        product = Product.query.get(item['id'])
+        if not product:
+            continue
+        product.name = item.get('name', product.name)
+        product.description = item.get('description', product.description)
+        product.price = item.get('price', product.price)
+        updated.append(product)
+    db.session.commit()
+    return updated

--- a/backend/app/services/requests.py
+++ b/backend/app/services/requests.py
@@ -14,6 +14,18 @@ def create_request(requester_id, product_id, action, quantity, location_id):
     return approval
 
 
+def create_draft_request(requester_id, product_id, action, quantity, location_id):
+    approval = ApprovalRequest(requester_id=int(requester_id),
+                               product_id=product_id,
+                               action=action,
+                               quantity=quantity,
+                               location_id=location_id,
+                               status='draft')
+    db.session.add(approval)
+    db.session.commit()
+    return approval
+
+
 def approve_request(request_obj, approver_id):
     request_obj.status = 'approved'
     request_obj.approver_id = approver_id
@@ -35,3 +47,40 @@ def deny_request(request_obj, approver_id):
     request_obj.status = 'denied'
     request_obj.approver_id = approver_id
     db.session.commit()
+
+
+def bulk_approve_requests(ids, approver_id):
+    """Approve multiple requests in a single transaction."""
+    requests = []
+    for rid in ids:
+        req = ApprovalRequest.query.get(rid)
+        if req and req.status == 'pending':
+            req.status = 'approved'
+            req.approver_id = approver_id
+            inv = Inventory.query.filter_by(product_id=req.product_id,
+                                            location_id=req.location_id).first()
+            if not inv:
+                inv = Inventory(product_id=req.product_id,
+                                 location_id=req.location_id,
+                                 quantity=0)
+                db.session.add(inv)
+            if req.action == 'add':
+                inv.quantity += req.quantity
+            elif req.action == 'remove':
+                inv.quantity = max(0, inv.quantity - req.quantity)
+            requests.append(req)
+    db.session.commit()
+    return requests
+
+
+def bulk_deny_requests(ids, approver_id):
+    """Deny multiple requests."""
+    requests = []
+    for rid in ids:
+        req = ApprovalRequest.query.get(rid)
+        if req and req.status == 'pending':
+            req.status = 'denied'
+            req.approver_id = approver_id
+            requests.append(req)
+    db.session.commit()
+    return requests

--- a/backend/tests/test_orders.py
+++ b/backend/tests/test_orders.py
@@ -1,0 +1,37 @@
+import json
+from flask_jwt_extended import create_access_token
+from backend.app import create_app, db
+from backend.app.models import Role, User
+
+
+def setup_app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        stock_role = Role(name='Stockist')
+        man_role = Role(name='Manufacturer')
+        db.session.add_all([stock_role, man_role, Role(name='CFA')])
+        db.session.commit()
+        stock = User(username='st', email='s@example.com', password_hash=User.generate_hash('pass'), role=stock_role)
+        db.session.add(stock)
+        db.session.commit()
+    return app
+
+
+def test_order_creation():
+    app = setup_app()
+    client = app.test_client()
+    with app.app_context():
+        stock = User.query.filter_by(username='st').first()
+        token = create_access_token(identity=str(stock.id), additional_claims={'role': 'Stockist'})
+    headers = {'Authorization': f'Bearer {token}'}
+    resp = client.post('/orders/', json={'items': [{'product_id':1,'qty':2}]}, headers=headers)
+    assert resp.status_code == 201
+    order_id = json.loads(resp.data)['id']
+    resp = client.get('/orders/', headers=headers)
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    assert any(o['id'] == order_id for o in data)

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,0 +1,34 @@
+import json
+from flask_jwt_extended import create_access_token
+from backend.app import create_app, db
+from backend.app.models import Role, User
+
+
+def setup_app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        stock_role = Role(name='Stockist')
+        db.session.add_all([stock_role, Role(name='Manufacturer'), Role(name='CFA')])
+        db.session.commit()
+        user = User(username='st', email='s@example.com', password_hash=User.generate_hash('pass'), role=stock_role)
+        db.session.add(user)
+        db.session.commit()
+    return app
+
+
+def test_profile_update():
+    app = setup_app()
+    client = app.test_client()
+    with app.app_context():
+        user = User.query.filter_by(username='st').first()
+        token = create_access_token(identity=str(user.id), additional_claims={'role': 'Stockist'})
+    headers = {'Authorization': f'Bearer {token}'}
+    resp = client.put('/users/me', json={'username': 'new'}, headers=headers)
+    assert resp.status_code == 200
+    resp = client.get('/users/me', headers=headers)
+    data = json.loads(resp.data)
+    assert data['username'] == 'new'

--- a/frontend/assets/js/api.js
+++ b/frontend/assets/js/api.js
@@ -14,3 +14,5 @@ if (typeof module !== 'undefined') {
 if (typeof window !== 'undefined') {
   window.apiFetch = apiFetch;
 }
+
+export { apiFetch };

--- a/frontend/assets/js/manufacturer.js
+++ b/frontend/assets/js/manufacturer.js
@@ -6,4 +6,47 @@ async function loadProducts() {
   console.log(data);
 }
 
-window.addEventListener('load', loadProducts);
+export async function bulkApprove(ids) {
+  await window.apiFetch('/requests/bulk-approve', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ids })
+  });
+}
+
+export async function bulkDeny(ids) {
+  await window.apiFetch('/requests/bulk-deny', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ids })
+  });
+}
+
+export async function uploadProducts(list) {
+  await window.apiFetch('/products/bulk', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(list)
+  });
+}
+
+export async function updateProducts(list) {
+  await window.apiFetch('/products/bulk', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(list)
+  });
+}
+
+async function loadAnalytics() {
+  const ctx = document.getElementById('salesChart');
+  if (!ctx) return;
+  const resp = await window.apiFetch('/analytics/sales');
+  const data = await resp.json();
+  window.renderSalesChart(ctx, data);
+}
+
+window.addEventListener('load', () => {
+  loadProducts();
+  loadAnalytics();
+});

--- a/frontend/assets/js/stockist.js
+++ b/frontend/assets/js/stockist.js
@@ -5,4 +5,46 @@ async function loadCatalog() {
   console.log('catalog', data);
 }
 
+export function getCart() {
+  return JSON.parse(localStorage.getItem('cart') || '[]');
+}
+
+export function saveCart(cart) {
+  localStorage.setItem('cart', JSON.stringify(cart));
+}
+
+export function addToCart(item) {
+  const cart = getCart();
+  const existing = cart.find(i => i.product_id === item.product_id);
+  if (existing) existing.qty += item.qty; else cart.push(item);
+  saveCart(cart);
+}
+
+export function removeFromCart(product_id) {
+  const cart = getCart().filter(i => i.product_id !== product_id);
+  saveCart(cart);
+}
+
+export async function checkout() {
+  const cart = getCart();
+  await window.apiFetch('/orders/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ items: cart })
+  });
+  saveCart([]);
+}
+
+export async function updateProfile(data) {
+  await window.apiFetch('/users/me', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+}
+
 window.addEventListener('load', loadCatalog);
+
+if (typeof module !== 'undefined') {
+  module.exports = { getCart, saveCart, addToCart, removeFromCart };
+}

--- a/frontend/charts/analytics.js
+++ b/frontend/charts/analytics.js
@@ -1,0 +1,18 @@
+import Chart from 'chart.js/auto';
+
+export function renderSalesChart(ctx, data) {
+  return new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: data.labels,
+      datasets: [{ label: 'Sales', data: data.values }]
+    }
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.renderSalesChart = renderSalesChart;
+}
+if (typeof module !== 'undefined') {
+  module.exports = { renderSalesChart };
+}

--- a/frontend/pages/manufacturer.html
+++ b/frontend/pages/manufacturer.html
@@ -6,7 +6,10 @@
 </head>
 <body>
 <h1>Manufacturer Dashboard</h1>
+<canvas id="salesChart" width="400" height="200"></canvas>
 <script src="../assets/js/api.js"></script>
+<script src="../node_modules/chart.js/dist/chart.umd.js"></script>
+<script type="module" src="../charts/analytics.js"></script>
 <script type="module" src="../assets/js/manufacturer.js"></script>
 <script>
   if ('serviceWorker' in navigator) {

--- a/frontend/pages/stockist.html
+++ b/frontend/pages/stockist.html
@@ -6,12 +6,24 @@
 </head>
 <body>
 <h1>Stockist Dashboard</h1>
+<div id="cart"></div>
+<button id="checkoutBtn">Checkout</button>
 <script src="../assets/js/api.js"></script>
 <script type="module" src="../assets/js/stockist.js"></script>
 <script>
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('../service-worker.js');
   }
+</script>
+<script type="module">
+  import { getCart, checkout } from '../assets/js/stockist.js';
+  document.getElementById('checkoutBtn').addEventListener('click', checkout);
+  function renderCart() {
+    const cart = getCart();
+    document.getElementById('cart').textContent = JSON.stringify(cart);
+  }
+  window.addEventListener('storage', renderCart);
+  renderCart();
 </script>
 </body>
 </html>

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -1,4 +1,5 @@
-const { apiFetch } = require('../assets/js/api.js');
+import { jest } from '@jest/globals';
+import { apiFetch } from '../assets/js/api.js';
 global.fetch = jest.fn(() => Promise.resolve({ status: 200 }));
 localStorage.setItem('token', 'abc');
 

--- a/frontend/tests/cart.test.js
+++ b/frontend/tests/cart.test.js
@@ -1,0 +1,16 @@
+let mod;
+beforeAll(async () => {
+  mod = await import('../assets/js/stockist.js');
+});
+
+test('addToCart stores item', () => {
+  localStorage.clear();
+  mod.addToCart({ product_id: 1, qty: 2 });
+  expect(mod.getCart()).toEqual([{ product_id: 1, qty: 2 }]);
+});
+
+test('removeFromCart removes item', () => {
+  mod.saveCart([{ product_id: 1, qty: 2 }]);
+  mod.removeFromCart(1);
+  expect(mod.getCart()).toEqual([]);
+});

--- a/frontend/tests/charts.test.js
+++ b/frontend/tests/charts.test.js
@@ -1,0 +1,13 @@
+let renderSalesChart;
+beforeAll(async () => {
+  ({ renderSalesChart } = await import('../charts/analytics.js'));
+  HTMLCanvasElement.prototype.getContext = () => ({});
+});
+
+test('renderSalesChart initializes Chart', () => {
+  document.body.innerHTML = '<canvas id="c"></canvas>';
+  const ctx = document.getElementById('c');
+  const chart = renderSalesChart(ctx, { labels: ['A'], values: [1] });
+  expect(chart).toBeDefined();
+  chart.destroy();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "chart.js": "^4.4.1",
         "idb": "^8.0.3",
         "jest": "^30.0.2",
         "jest-environment-jsdom": "^30.0.2"
@@ -1080,6 +1081,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz",
@@ -1817,6 +1824,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/ci-info": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This repository contains plans for an advanced, enterprise-level Supply Chain Management (SCM) system designed specifically for pharmaceutical manufacturers, Clearing & Forwarding Agents (CFAs), and stockists. The system ensures a tightly controlled in-house process flow where the Manufacturer retains authoritative oversight, with all CFA actions requiring explicit Manufacturer approval.",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "keywords": [],
   "author": "",
@@ -12,6 +12,7 @@
   "type": "module",
   "dependencies": {
     "idb": "^8.0.3",
+    "chart.js": "^4.4.1",
     "jest": "^30.0.2",
     "jest-environment-jsdom": "^30.0.2"
   },


### PR DESCRIPTION
## Summary
- add order model and related routes
- implement bulk product create/update
- extend request listing filters and add bulk approve/deny endpoints
- add draft request route
- expose cart helpers and checkout flow
- integrate Chart.js with analytics script
- update manufacturer and stockist pages
- add profile update API
- provide backend and frontend unit tests

## Testing
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68593a93f2f8832a85989f15d7e69dfc