### PR TITLE
Implement manufacturer bulk selection UI and tests

### DIFF
--- a/backend/tests/test_requests.py
+++ b/backend/tests/test_requests.py
@@ -57,3 +57,41 @@ def test_bulk_approval():
     resp = client.get('/inventory/', headers=headers_cfa)
     data = json.loads(resp.data)
     assert any(i['product_id']==1 and i['quantity']==4 for i in data)
+
+
+def test_bulk_deny():
+    app = setup_app()
+    client = app.test_client()
+    with app.app_context():
+        cfa = User.query.filter_by(username='cfa').first()
+        man = User.query.filter_by(username='man').first()
+        cfa_token = create_access_token(identity=str(cfa.id), additional_claims={'role': 'CFA'})
+        man_token = create_access_token(identity=str(man.id), additional_claims={'role': 'Manufacturer'})
+    headers_cfa = {'Authorization': f'Bearer {cfa_token}'}
+    ids = []
+    for _ in range(2):
+        resp = client.post('/requests/', json={'product_id':1,'action':'add','quantity':2,'location_id':1}, headers=headers_cfa)
+        ids.append(json.loads(resp.data)['id'])
+    resp = client.put('/requests/bulk-deny', json={'ids': ids}, headers={'Authorization': f'Bearer {man_token}'})
+    assert resp.status_code == 200
+    with app.app_context():
+        from backend.app.models import ApprovalRequest
+        statuses = [ApprovalRequest.query.get(i).status for i in ids]
+    assert all(s == 'denied' for s in statuses)
+
+
+def test_request_product_filter():
+    app = setup_app()
+    client = app.test_client()
+    with app.app_context():
+        cfa = User.query.filter_by(username='cfa').first()
+        man = User.query.filter_by(username='man').first()
+        cfa_token = create_access_token(identity=str(cfa.id), additional_claims={'role': 'CFA'})
+        man_token = create_access_token(identity=str(man.id), additional_claims={'role': 'Manufacturer'})
+    headers_cfa = {'Authorization': f'Bearer {cfa_token}'}
+    client.post('/requests/', json={'product_id':1,'action':'add','quantity':1,'location_id':1}, headers=headers_cfa)
+    client.post('/requests/', json={'product_id':2,'action':'add','quantity':1,'location_id':1}, headers=headers_cfa)
+    resp = client.get('/requests/?product=1', headers={'Authorization': f'Bearer {man_token}'})
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    assert all(r['product_id'] == 1 for r in data)

--- a/frontend/assets/js/manufacturer.js
+++ b/frontend/assets/js/manufacturer.js
@@ -6,6 +6,23 @@ async function loadProducts() {
   console.log(data);
 }
 
+async function loadRequests() {
+  const resp = await window.apiFetch('/requests?status=pending');
+  const data = await resp.json();
+  const list = document.getElementById('requestsList');
+  if (!list) return;
+  list.innerHTML = '';
+  data.forEach(r => {
+    const li = document.createElement('li');
+    li.innerHTML = `<label><input type="checkbox" class="req-check" value="${r.id}">Request ${r.id} (${r.action} ${r.quantity})</label>`;
+    list.appendChild(li);
+  });
+}
+
+function getSelectedIds() {
+  return Array.from(document.querySelectorAll('.req-check:checked')).map(c => parseInt(c.value));
+}
+
 export async function bulkApprove(ids) {
   await window.apiFetch('/requests/bulk-approve', {
     method: 'PUT',
@@ -49,4 +66,25 @@ async function loadAnalytics() {
 window.addEventListener('load', () => {
   loadProducts();
   loadAnalytics();
+  loadRequests();
+  const approveBtn = document.getElementById('approveSelected');
+  const denyBtn = document.getElementById('denySelected');
+  if (approveBtn) {
+    approveBtn.addEventListener('click', async () => {
+      const ids = getSelectedIds();
+      if (ids.length) {
+        await bulkApprove(ids);
+        loadRequests();
+      }
+    });
+  }
+  if (denyBtn) {
+    denyBtn.addEventListener('click', async () => {
+      const ids = getSelectedIds();
+      if (ids.length) {
+        await bulkDeny(ids);
+        loadRequests();
+      }
+    });
+  }
 });

--- a/frontend/pages/manufacturer.html
+++ b/frontend/pages/manufacturer.html
@@ -7,6 +7,9 @@
 <body>
 <h1>Manufacturer Dashboard</h1>
 <canvas id="salesChart" width="400" height="200"></canvas>
+<ul id="requestsList"></ul>
+<button id="approveSelected">Approve Selected</button>
+<button id="denySelected">Deny Selected</button>
 <script src="../assets/js/api.js"></script>
 <script src="../node_modules/chart.js/dist/chart.umd.js"></script>
 <script type="module" src="../charts/analytics.js"></script>


### PR DESCRIPTION
## Summary
- add request list and bulk action buttons to manufacturer dashboard
- handle request selection and bulk approve/deny in manufacturer.js
- test bulk deny endpoint and request filtering

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68593d03b960832a8f54d90bec6b3dc2