### PR TITLE
Fix run script import and add port option

### DIFF
--- a/backend/run.py
+++ b/backend/run.py
@@ -1,6 +1,13 @@
-from app import create_app
+# Allow running the app either as ``python run.py`` from the ``backend`` folder
+# or via ``python -m backend.run`` from the project root. Importing using the
+# absolute package path avoids issues with relative imports.
+from backend.app import create_app
 
 app = create_app()
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    # Allow overriding port via the ``PORT`` environment variable. This helps
+    # avoid conflicts if port 5000 is already in use when testing.
+    import os
+    port = int(os.environ.get('PORT', 5000))
+    app.run(debug=True, port=port)


### PR DESCRIPTION
## Summary
- fix module import in `backend/run.py`
- allow overriding the run port via the `PORT` environment variable

## Testing
- `pytest backend/tests`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68593eed44c4832aa65243f47004a373