### PR TITLE
Add manufacturer registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,14 @@ python run.py
 ### Frontend
 
 - Serve the `frontend` directory via a local or HTTP server
-- Alternatively open `index.html` in browser
+- Alternatively open `index.html` in browser. A dedicated manufacturer
+  registration page is available at `pages/register.html`. The backend also
+  seeds a sample manufacturer account on first run:
+
+  ```
+  username: samplemanufacturer
+  password: samplepass
+  ```
 
 ## Authentication and Security
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -35,5 +35,26 @@ def create_app(config_class=None):
 
     with app.app_context():
         db.create_all()
+        # Ensure default roles exist
+        from .models import Role, User
+        if not Role.query.filter_by(name='Manufacturer').first():
+            db.session.add(Role(name='Manufacturer'))
+        if not Role.query.filter_by(name='CFA').first():
+            db.session.add(Role(name='CFA'))
+        if not Role.query.filter_by(name='Stockist').first():
+            db.session.add(Role(name='Stockist'))
+        db.session.commit()
+
+        # Create a sample manufacturer account if it doesn't exist
+        if not User.query.filter_by(username='samplemanufacturer').first():
+            manu_role = Role.query.filter_by(name='Manufacturer').first()
+            sample = User(
+                username='samplemanufacturer',
+                email='sample@scm.com',
+                password_hash=User.generate_hash('samplepass'),
+                role=manu_role
+            )
+            db.session.add(sample)
+            db.session.commit()
 
     return app

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -7,6 +7,8 @@ class User(db.Model):
     email = db.Column(db.String(120), unique=True, nullable=False)
     password_hash = db.Column(db.String(128), nullable=False)
     role_id = db.Column(db.Integer, db.ForeignKey('role.id'), nullable=False)
+    created_by_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    created_users = db.relationship('User', backref=db.backref('creator', remote_side=[id]), lazy=True)
 
     @staticmethod
     def generate_hash(password):

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -12,14 +12,17 @@ def register():
     username = data.get('username')
     email = data.get('email')
     password = data.get('password')
-    role_name = data.get('role', 'Stockist')
+    role_name = data.get('role', 'Manufacturer')
 
     if not username or not email or not password:
         return jsonify({'msg': 'Missing required fields'}), 400
 
-    role = Role.query.filter_by(name=role_name).first()
+    if role_name != 'Manufacturer':
+        return jsonify({'msg': 'Only manufacturer registration allowed'}), 403
+
+    role = Role.query.filter_by(name='Manufacturer').first()
     if role is None:
-        role = Role(name=role_name)
+        role = Role(name='Manufacturer')
         db.session.add(role)
         db.session.commit()
 

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -2,10 +2,37 @@ from flask import Blueprint, request, jsonify
 from flask_jwt_extended import get_jwt_identity
 
 from .. import db
-from ..models import User
+from ..models import User, Role
 from ...utils.decorators import role_required
 
 users_bp = Blueprint('users', __name__)
+
+
+@users_bp.route('/', methods=['POST'])
+@role_required('Manufacturer')
+def create_user():
+    data = request.get_json() or {}
+    username = data.get('username')
+    email = data.get('email')
+    password = data.get('password')
+    role_name = data.get('role')
+
+    if not username or not email or not password or role_name not in ['CFA', 'Stockist']:
+        return jsonify({'msg': 'invalid data'}), 400
+
+    role = Role.query.filter_by(name=role_name).first()
+    if role is None:
+        role = Role(name=role_name)
+        db.session.add(role)
+        db.session.commit()
+
+    creator_id = get_jwt_identity()
+    user = User(username=username, email=email,
+                password_hash=User.generate_hash(password), role=role,
+                created_by_id=creator_id)
+    db.session.add(user)
+    db.session.commit()
+    return jsonify({'id': user.id}), 201
 
 
 @users_bp.route('/me', methods=['GET'])

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -26,3 +26,10 @@ def test_register_and_login():
     assert resp.status_code == 200
     data = json.loads(resp.data)
     assert 'access_token' in data
+
+
+def test_register_non_manufacturer_forbidden():
+    app = setup_app()
+    client = app.test_client()
+    resp = client.post('/auth/register', json={'username': 'cfa', 'email': 'cfa@example.com', 'password': 'pass', 'role': 'CFA'})
+    assert resp.status_code == 403

--- a/frontend/assets/js/register.js
+++ b/frontend/assets/js/register.js
@@ -1,0 +1,21 @@
+async function register(e) {
+  e.preventDefault();
+  const data = {
+    username: document.getElementById('username').value,
+    email: document.getElementById('email').value,
+    password: document.getElementById('password').value
+  };
+  const resp = await window.apiFetch('/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  if (resp.ok) {
+    alert('Registered');
+  } else {
+    const t = await resp.json();
+    alert(t.msg || 'error');
+  }
+}
+
+document.getElementById('regForm').addEventListener('submit', register);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,5 +5,6 @@
 </head>
 <body>
     <h1>Welcome to the SCM System</h1>
+    <p><a href="pages/register.html">Register as Manufacturer</a></p>
 </body>
 </html>

--- a/frontend/pages/register.html
+++ b/frontend/pages/register.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Manufacturer Registration</title>
+</head>
+<body>
+  <h1>Register Manufacturer</h1>
+  <form id="regForm">
+    <input type="text" id="username" placeholder="Username" required><br>
+    <input type="email" id="email" placeholder="Email" required><br>
+    <input type="password" id="password" placeholder="Password" required><br>
+    <button type="submit">Register</button>
+  </form>
+  <script src="../assets/js/register.js" type="module"></script>
+  <script>
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('../service-worker.js');
+  }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- restrict `/auth/register` to manufacturer role
- allow manufacturer to create CFA and Stockist accounts
- store creator relationship in the user model
- seed a sample manufacturer user on startup
- add registration form and script on the frontend
- document sample account credentials
- update tests for new logic

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685948a8756c832a99f5b5ff2500606e