### PR TITLE
Add simple setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,22 +119,21 @@ supply-chain-management/
 
 ## Installation and Setup
 
-The following commands reflect the intended project structure.  The repository currently lacks the `backend` and `frontend` directories, so these steps serve as guidance for future implementation.
-
-### Backend
+All dependencies can be installed and the development servers started with a
+single helper script:
 
 ```sh
-cd backend
-pip install -r requirements.txt
-python run.py
+./setup_and_run.sh
 ```
 
-### Frontend
+The script installs the Python packages in `backend/`, installs the frontend
+Node.js packages and then launches the Flask API on
+`http://localhost:5000` and a simple static server for the frontend on
+`http://localhost:8000`.
 
-- Serve the `frontend` directory via a local or HTTP server
-- Alternatively open `index.html` in browser. A dedicated manufacturer
-  registration page is available at `pages/register.html`. The backend also
-  seeds a sample manufacturer account on first run:
+After running the script you can open `http://localhost:8000/pages/register.html`
+to register the first manufacturer account.  The backend also seeds a sample
+manufacturer account on first run:
 
   ```
   username: samplemanufacturer

--- a/setup_and_run.sh
+++ b/setup_and_run.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# install backend dependencies
+pip install -r backend/requirements.txt
+
+# install frontend dependencies
+npm install
+
+# start backend server in background
+python backend/run.py &
+BACK_PID=$!
+
+# serve frontend using python http server
+cd frontend
+python -m http.server 8000 &
+FRONT_PID=$!
+cd ..
+
+# display registration page URL
+echo "Backend running at http://localhost:5000"
+echo "Open http://localhost:8000/pages/register.html to register a manufacturer account"
+
+# wait for background processes
+wait $BACK_PID $FRONT_PID


### PR DESCRIPTION
## Summary
- add `setup_and_run.sh` helper to install deps and run dev servers
- document new script in the README

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68594d4de7ec832ab50f7cc1c3cc7751