### PR TITLE
Add URL health check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,19 @@ manufacturer account on first run:
   password: samplepass
   ```
 
+## URL Health Check
+
+To verify that both the backend API and frontend pages are reachable you can run
+the helper script:
+
+```sh
+./scripts/curl_test_all.sh
+```
+
+By default it checks `http://localhost:5000` for API endpoints and
+`http://localhost:8000` for frontend pages. Set the `BACKEND` or `FRONTEND`
+environment variables to override the base URLs.
+
 ## Authentication and Security
 
 - JWT-based token validation

--- a/scripts/curl_test_all.sh
+++ b/scripts/curl_test_all.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Simple health check script for frontend and backend URLs
+# Usage: BACKEND=http://localhost:5000 FRONTEND=http://localhost:8000 ./curl_test_all.sh
+
+set -e
+
+BACKEND=${BACKEND:-http://localhost:5000}
+FRONTEND=${FRONTEND:-http://localhost:8000}
+
+backend_endpoints=(
+  "/auth/register"
+  "/auth/login"
+  "/products/"
+  "/inventory/"
+  "/requests/"
+  "/orders/"
+  "/users/"
+)
+
+frontend_paths=(
+  "/"
+  "/pages/register.html"
+  "/pages/manufacturer.html"
+  "/pages/cfa.html"
+  "/pages/stockist.html"
+)
+
+echo "Checking backend endpoints"
+for ep in "${backend_endpoints[@]}"; do
+  url="$BACKEND$ep"
+  printf '%-40s' "$url"
+  curl -Ls -o /dev/null -w '%{http_code} -> %{url_effective}\n' "$url"
+done
+
+echo ""
+echo "Checking frontend pages"
+for path in "${frontend_paths[@]}"; do
+  url="$FRONTEND$path"
+  printf '%-40s' "$url"
+  curl -Ls -o /dev/null -w '%{http_code} -> %{url_effective}\n' "$url"
+done


### PR DESCRIPTION
## Summary
- add script to verify major backend and frontend URLs with curl
- document the `curl_test_all.sh` script in README

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685952043ecc832a97b4f432c19d7467