### PR TITLE
Add login with role-based redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,10 @@ Node.js packages and then launches the Flask API on
 `http://localhost:8000`.
 
 After running the script you can open `http://localhost:8000/pages/register.html`
-to register the first manufacturer account.  The backend also seeds a sample
-manufacturer account on first run:
+to register the first manufacturer account or simply use the seeded login
+below.  Sign in via `http://localhost:8000/pages/login.html`; the page will
+redirect to the appropriate dashboard based on the authenticated user's role.
+The backend seeds a sample manufacturer account on first run:
 
   ```
   username: samplemanufacturer

--- a/frontend/assets/js/login.js
+++ b/frontend/assets/js/login.js
@@ -1,0 +1,37 @@
+import { apiFetch } from './api.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('loginForm');
+  if (!form) return;
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('password').value;
+    const resp = await apiFetch('/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ username, password })
+    });
+    if (resp.ok) {
+      const data = await resp.json();
+      localStorage.setItem('token', data.access_token);
+      try {
+        const payload = JSON.parse(atob(data.access_token.split('.')[1]));
+        const role = payload.role;
+        if (role === 'Manufacturer') {
+          window.location.href = 'manufacturer.html';
+        } else if (role === 'CFA') {
+          window.location.href = 'cfa.html';
+        } else if (role === 'Stockist') {
+          window.location.href = 'stockist.html';
+        } else {
+          alert('Unknown role');
+        }
+      } catch (err) {
+        console.error(err);
+        alert('Invalid token');
+      }
+    } else {
+      alert('Invalid credentials');
+    }
+  });
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,5 +6,6 @@
 <body>
     <h1>Welcome to the SCM System</h1>
     <p><a href="pages/register.html">Register as Manufacturer</a></p>
+    <p><a href="pages/login.html">Login</a></p>
 </body>
 </html>

--- a/frontend/pages/login.html
+++ b/frontend/pages/login.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Login</title>
+</head>
+<body>
+  <h1>Login</h1>
+  <form id="loginForm">
+    <input type="text" id="username" placeholder="Username" required><br>
+    <input type="password" id="password" placeholder="Password" required><br>
+    <button type="submit">Login</button>
+  </form>
+  <script src="../assets/js/api.js"></script>
+  <script type="module" src="../assets/js/login.js"></script>
+  <script>
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('../service-worker.js');
+  }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a basic login page and login script
- redirect users to the correct dashboard based on their role
- link to login page from the index
- document the login page and sample credentials

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859542aed48832a8a01716000fda48c