### PR TITLE
Serve frontend via Flask

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,16 +129,11 @@ Run the following commands from the repository root:
 # install backend dependencies
 pip install -r backend/requirements.txt
 
-# start the Flask API on http://localhost:5000
-python -m backend.run &
-
 # install frontend dependencies
 npm install
 
-# serve the static pages on http://localhost:8000
-cd frontend
-python -m http.server 8000 &
-cd ..
+# start the Flask server (serves API and frontend) on http://localhost:5000
+python -m backend.run
 ```
 
 ### 2. Helper script
@@ -154,11 +149,11 @@ defaults to `http://localhost:5000`, but you can override this by defining a
 `window.API_BASE` variable **before** loading `assets/js/api.js` when deploying
 against a different backend address.
 
-The script performs the same steps as above and launches both servers.
+The script performs the same steps as above and launches the single Flask server.
 
-Once running, open `http://localhost:8000/pages/register.html` to register the
+Once running, open `http://localhost:5000/pages/register.html` to register the
 first manufacturer account or use the seeded credentials below to sign in via
-`http://localhost:8000/pages/login.html`. The page will redirect to the
+`http://localhost:5000/pages/login.html`. The page will redirect to the
 appropriate dashboard based on the authenticated user's role.  The backend seeds
 a sample manufacturer account on first run:
 
@@ -176,9 +171,9 @@ the helper script:
 ./scripts/curl_test_all.sh
 ```
 
-By default it checks `http://localhost:5000` for API endpoints and
-`http://localhost:8000` for frontend pages. Set the `BACKEND` or `FRONTEND`
-environment variables to override the base URLs.
+By default it checks `http://localhost:5000` for both API endpoints and frontend
+pages. Set the `BACKEND` or `FRONTEND` environment variables to override the
+base URLs if needed.
 
 ## Authentication and Security
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -25,6 +25,7 @@ def create_app(config_class=None):
     from .routes.requests import requests_bp
     from .routes.orders import orders_bp
     from .routes.users import users_bp
+    from .routes.frontend import frontend_bp
 
     app.register_blueprint(auth_bp, url_prefix='/auth')
     app.register_blueprint(products_bp, url_prefix='/products')
@@ -32,6 +33,9 @@ def create_app(config_class=None):
     app.register_blueprint(requests_bp, url_prefix='/requests')
     app.register_blueprint(orders_bp, url_prefix='/orders')
     app.register_blueprint(users_bp, url_prefix='/users')
+    # Serve frontend files via Flask so one server handles both frontend
+    # and backend when running ``backend.run``.
+    app.register_blueprint(frontend_bp)
 
     with app.app_context():
         db.create_all()

--- a/backend/app/routes/frontend.py
+++ b/backend/app/routes/frontend.py
@@ -1,0 +1,23 @@
+from flask import Blueprint, send_from_directory
+from pathlib import Path
+
+# Path to the repository root -> parent of backend directory
+ROOT_DIR = Path(__file__).resolve().parents[3]
+FRONTEND_DIR = ROOT_DIR / 'frontend'
+
+frontend_bp = Blueprint(
+    'frontend', __name__,
+    static_folder=str(FRONTEND_DIR),
+    template_folder=str(FRONTEND_DIR)
+)
+
+@frontend_bp.route('/')
+def index():
+    """Serve the main index page."""
+    return send_from_directory(frontend_bp.static_folder, 'index.html')
+
+
+@frontend_bp.route('/<path:filename>')
+def static_files(filename):
+    """Serve frontend files for any other path."""
+    return send_from_directory(frontend_bp.static_folder, filename)

--- a/scripts/curl_test_all.sh
+++ b/scripts/curl_test_all.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # Simple health check script for frontend and backend URLs
-# Usage: BACKEND=http://localhost:5000 FRONTEND=http://localhost:8000 ./curl_test_all.sh
+# Usage: BACKEND=http://localhost:5000 FRONTEND=http://localhost:5000 ./curl_test_all.sh
 
 set -e
 
 BACKEND=${BACKEND:-http://localhost:5000}
-FRONTEND=${FRONTEND:-http://localhost:8000}
+# By default frontend uses the same base URL as the backend since Flask serves both.
+FRONTEND=${FRONTEND:-$BACKEND}
 
 backend_endpoints=(
   "/auth/register"

--- a/setup_and_run.sh
+++ b/setup_and_run.sh
@@ -7,19 +7,13 @@ pip install -r backend/requirements.txt
 # install frontend dependencies
 npm install
 
-# start backend server in background
+# start backend server (also serves frontend) in background
 python backend/run.py &
 BACK_PID=$!
 
-# serve frontend using python http server
-cd frontend
-python -m http.server 8000 &
-FRONT_PID=$!
-cd ..
-
 # display registration page URL
-echo "Backend running at http://localhost:5000"
-echo "Open http://localhost:8000/pages/register.html to register a manufacturer account"
+echo "Server running at http://localhost:5000"
+echo "Open http://localhost:5000/pages/register.html to register a manufacturer account"
 
-# wait for background processes
-wait $BACK_PID $FRONT_PID
+# wait for the server process
+wait $BACK_PID


### PR DESCRIPTION
## Summary
- serve static frontend files from Flask using a new blueprint
- run only one server in `setup_and_run.sh`
- update health check script and README to reflect unified server

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685965adf350832aba4e2754d96d9dea